### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/Soda/keywords.txt
+++ b/Soda/keywords.txt
@@ -1,4 +1,4 @@
-Soda  KEYWORD1
+Soda	KEYWORD1
 pins	KEYWORD2
 write	KEYWORD2
 setDecimalState		KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords